### PR TITLE
Fix spread in LaMa node

### DIFF
--- a/py/lama.py
+++ b/py/lama.py
@@ -67,7 +67,7 @@ class LaMa:
                     _mask = tensor2pil(expand_mask(image2mask(_mask), mask_grow, mask_blur))
                 
                 ret_image = pixel_spread(tensor2pil(_image).convert('RGB'), ImageChops.invert(_mask.convert('RGB')))
-                ret_images.append(ret_image)
+                ret_images.append(pil2tensor(ret_image))
         else:
             temp_dir = os.path.join(folder_paths.get_temp_directory(), generate_random_name('_lama_', '_temp', 16))
             if os.path.isdir(temp_dir):


### PR DESCRIPTION
The LaMa node expects ret_images to be a list of tensors, but when using the 'spread' mode the images never get converted back into tensors causing an exception.

This fixes things, though maybe there's a better spot for the conversion.