### PR TITLE
Enabled remote VitMatte Model download

### DIFF
--- a/py/imagefunc.py
+++ b/py/imagefunc.py
@@ -1539,9 +1539,9 @@ class VITMatteModel:
         self.processor = processor
 
 def load_VITMatte_model(model_name:str, local_files_only:bool=False) -> object:
-    # if local_files_only:
-    #     model_name = Path(os.path.join(folder_paths.models_dir, "vitmatte"))
-    model_name = Path(os.path.join(folder_paths.models_dir, "vitmatte"))
+    if local_files_only:
+        model_name = Path(os.path.join(folder_paths.models_dir, "vitmatte"))
+    # model_name = Path(os.path.join(folder_paths.models_dir, "vitmatte"))
     from transformers import VitMatteImageProcessor, VitMatteForImageMatting
     model = VitMatteForImageMatting.from_pretrained(model_name, local_files_only=local_files_only)
     processor = VitMatteImageProcessor.from_pretrained(model_name, local_files_only=local_files_only)


### PR DESCRIPTION
Hey there, I am not sure why these two lines were commented out. Maybe for Chinese Users? I tried “fixing” this and it seems working fine for both local & remote model. Could you please merge this? 

你好，我发现只要做以下改动，就能同时兼顾VitMatte（local）本地已下载模型和选择VitMatte后直接从huggingface远程下载，我阅读了一下调用该方法的代码，已经有足够的逻辑支撑该判定。我觉得这个远程下载模型的功能还是打开较好，特别是一些预装了贵节点的comfyui云，作为用户往往没法去上传模型，只能依赖远程下载。
谢谢。