### PR TITLE
refix READMEs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -76,7 +76,7 @@ Some JSON workflow files in the    ```workflow``` directory, That's examples of 
 
 ```
 ..\..\python\python.exe -s -m pip install -r requirements.txt
-.\repair_dependency.bat
+.\repair_dependency_aki.bat
 ```
 
 * Restart ComfyUI.

--- a/README_CN.MD
+++ b/README_CN.MD
@@ -66,7 +66,7 @@ git clone https://github.com/chflame163/ComfyUI_LayerStyle.git
 
 ```
 ..\..\python\python.exe -s -m pip install -r requirements.txt
-.\repair_dependency.bat
+.\repair_dependency_aki.bat
 ```
 * 重新打开ComfyUI。
 


### PR DESCRIPTION
About ```aki ComfyUI``` package install
Originally, in [merge #PR445](https://github.com/chflame163/ComfyUI_LayerStyle/commit/25bf27978aec1322afbacd216f5db64d2e269b71), the dependency installation instructions for ```aki comfy``` were updated, but in [next commit](https://github.com/chflame163/ComfyUI_LayerStyle/commit/eacb7ed3b66744e8617bfe839a78c82ede8795bf), that part was reverted. I re-checked the content of repair_dependency.bat, and for the ```aki comfy``` version, use ```python_exec=..\..\..\python_embeded\python.exe``` will error . Therefore, I believe this may have been an accidental operation. I will re-submit this change.