### PR TITLE
rmbg1.4: use "comfy.get_torch_device()" instead if "torch.cuda.is_available"

### DIFF
--- a/py/imagefunc.py
+++ b/py/imagefunc.py
@@ -1453,7 +1453,7 @@ def create_mask_from_color_tensor(image:Image, color:str, tolerance:int=0) -> Im
 def load_RMBG_model():
     from .briarmbg import BriaRMBG
     current_directory = os.path.dirname(os.path.abspath(__file__))
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = comfy.model_management.get_torch_device()
     net = BriaRMBG()
     model_path = ""
     try:


### PR DESCRIPTION
Hello, this is a one-line PR to fix the fact that the node for RMBG1.4 uses a device other than the one set in ComfyUI by default.

We still use RMBG1.4 instead of version 2.0, since in many pictures the old version is better...

And thank you for your node set!