### PR TITLE
fixed incorrect results for RmBgUltraV2 node

### DIFF
--- a/py/imagefunc.py
+++ b/py/imagefunc.py
@@ -1510,8 +1510,8 @@ def RMBG(image:Image) -> Image:
     mi = torch.min(result)
     result = (result - mi) / (ma - mi)
     im_array = (result * 255).cpu().data.numpy().astype(np.uint8)
-    _mask = torch.from_numpy(np.squeeze(im_array).astype(np.float32))
-    return tensor2pil(_mask)
+    return Image.fromarray(np.squeeze(im_array))
+
 
 def guided_filter_alpha(image:torch.Tensor, mask:torch.Tensor, filter_radius:int) -> torch.Tensor:
     sigma = 0.15


### PR DESCRIPTION
Resolves: #461


As far as I can see from what I'm testing, this fixes it and the results now match those excellent results as in the ZHO node.

But since I don't really know what to test when "process_detail=True" - I clicked a bit, it seems to have gotten better, but it's better to double-check.