### PR TITLE
fix: Fix opacity issue with transparent backgrounds

### DIFF
--- a/py/drop_shadow_v3.py
+++ b/py/drop_shadow_v3.py
@@ -1,7 +1,7 @@
 import torch
 from PIL import Image
 from .imagefunc import log, tensor2pil, pil2tensor, image2mask, mask2image
-from .imagefunc import chop_image_v2, chop_mode_v2, shift_image, expand_mask
+from .imagefunc import chop_image_v3, chop_mode_v2, shift_image, expand_mask
 
 
 
@@ -41,6 +41,7 @@ class DropShadowV3:
                        background_image=None, layer_mask=None
                        ):
 
+        background_image_was_provided = background_image is not None
         # If background image is empty, create transparent background image for each layer image
         if background_image == None:
             background_image = []
@@ -94,7 +95,7 @@ class DropShadowV3:
             shadow_mask = expand_mask(image2mask(__mask), grow, blur)  #扩张，模糊
             # 合成阴影
             alpha = tensor2pil(shadow_mask).convert('L')
-            _shadow = chop_image_v2(_canvas, shadow_color, blend_mode, opacity)
+            _shadow = chop_image_v3(_canvas, shadow_color, blend_mode, opacity, not background_image_was_provided)
             _canvas.paste(_shadow, mask=alpha)
             # 合成layer
             _canvas.paste(_layer, mask=_mask)

--- a/py/imagefunc.py
+++ b/py/imagefunc.py
@@ -380,6 +380,16 @@ def chop_image_v2(background_image:Image, layer_image:Image, blend_mode:str, opa
 
     return Image.fromarray(np.uint8(blended_np)).convert('RGB')
 
+def chop_image_v3(background_image:Image, layer_image:Image, blend_mode:str, opacity:int, alpha:bool) -> Image:
+
+    backdrop_prepped = np.asarray(background_image.convert('RGBA'), dtype=float)
+    source_prepped = np.asarray(layer_image.convert('RGBA'), dtype=float)
+    blended_np = BLEND_MODES[blend_mode](backdrop_prepped, source_prepped, opacity / 100)
+
+    if alpha:
+        return Image.fromarray(np.uint8(blended_np)).convert('RGBA')
+    return Image.fromarray(np.uint8(blended_np)).convert('RGB')
+
 def remove_background(image:Image, mask:Image, color:str) -> Image:
     width = image.width
     height = image.height


### PR DESCRIPTION
1. Fixed an issue where the `opacity` parameter was ineffective when no `background_image` was specified. This was because `chop_image_v2` was converting the shadow image to RGB format, discarding the alpha channel. Consequently, shadows appeared too dark when the background was transparent.
2. Introduced `chop_image_v3` which preserves alpha channel if no background image is specified.
3. Modified `DropShadowV3` to use `chop_image_v3` and pass flag about background presence.
4. This change ensures that opacity is correctly applied even with transparent backgrounds, resulting in more accurate and visually appealing shadow effects.