### PR TITLE
GH-602 fix: wrap importlib.import_module in try/except to prevent full plugin crash

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,8 +32,8 @@ for file in files:
     if not file.endswith(".py"):
         continue
     name = os.path.splitext(file)[0]
-    imported_module = importlib.import_module(".py.{}".format(name), __name__)
     try:
+        imported_module = importlib.import_module(".py.{}".format(name), __name__)
         NODE_CLASS_MAPPINGS = {**NODE_CLASS_MAPPINGS, **imported_module.NODE_CLASS_MAPPINGS}
         NODE_DISPLAY_NAME_MAPPINGS = {**NODE_DISPLAY_NAME_MAPPINGS, **imported_module.NODE_DISPLAY_NAME_MAPPINGS}
         serialized_CLASS_MAPPINGS = {k: serialize(v) for k, v in imported_module.NODE_CLASS_MAPPINGS.items()}


### PR DESCRIPTION
`import_module` was called outside the try/except block, so any single broken module (e.g. `color_name.py` referencing undefined `find_best_match_by_similarity`) crashes the entire plugin and prevents all 164+ nodes from registering.