### PR TITLE
fix: prevent duplicate COLOR widget on frontends with a native color widget

### DIFF
--- a/js/dz_mtb_widgets.js
+++ b/js/dz_mtb_widgets.js
@@ -23,7 +23,9 @@ const ensureColorWidgets = (node, nodeData) => {
   for (const [name, def] of Object.entries(required)) {
     const t = def?.[0]
     if (t === 'COLOR') {
-      const hasWidget = (node.widgets || []).some((w) => w.name === name && w.type === 'COLOR')
+      // Newer frontends create their own widget (type 'color') for COLOR inputs;
+      // match by name only so we never add a duplicate alongside it.
+      const hasWidget = (node.widgets || []).some((w) => w.name === name)
       if (!hasWidget && typeof node.addCustomWidget === 'function') {
         const defaultVal = def?.[1]?.default || '#ff0000'
         node.addCustomWidget(DZWidgets.COLOR(name, defaultVal))


### PR DESCRIPTION
<img width="571" height="481" alt="335a2db0ade56b6f128dc9b6d7e63622" src="https://github.com/user-attachments/assets/641dfcde-39ba-4d09-bae3-5355229149b4" />
